### PR TITLE
General changes/fixes to SOTH and Ao3

### DIFF
--- a/kod/object/active/holder/room/monsroom/marcry3a.kod
+++ b/kod/object/active/holder/room/monsroom/marcry3a.kod
@@ -215,7 +215,7 @@ properties:
    piBaseLight = LIGHT_VERY_DARK
    piOutside_factor = OUTDOORS_NONE
 
-   piMonster_count_max = 15
+   piMonster_count_max = 13
 
    poChest = $
 

--- a/kod/object/item/actitem/necroam.kod
+++ b/kod/object/item/actitem/necroam.kod
@@ -269,6 +269,8 @@ messages:
          AND IsClass(what,&User)
       {
          Post(self,@HoldingDamageTrigger);
+		 // Post these so that they happen after 'what' actually becomes our owner.
+		 Post(self,@AdjustStats);
       }
 
       if what <> $
@@ -291,6 +293,21 @@ messages:
 
             Send(what,@MsgSendUser,#message_rsc = ao3_no_spiritw);
          }
+      }
+	  // Remember, poOwner is still our old owner until we
+      // propagate all the way to object.
+      if poOwner <> $ // AND pbIn_Use
+         AND IsClass(poOwner,&User)
+      {
+         if ptHungerTimer <> $
+         {
+            DeleteTimer(ptHungerTimer);
+            ptHungerTimer = $;
+         }
+         pbIn_use = FALSE;
+
+         // Restore to original values - 1.
+         Send(self,@RestoreStats,#who=poOwner);
       }
 
       propagate;
@@ -386,43 +403,18 @@ messages:
             return FALSE;
          }
 
-         if pbWarned = FALSE
-         {
-            Send(what,@MsgSendUser,#message_rsc=necamulet_warning);
-            pbWarned = TRUE;
+         //if pbWarned = FALSE
+         //{
+         //   Send(what,@MsgSendUser,#message_rsc=necamulet_warning);
+         //   pbWarned = TRUE;
 
-            return FALSE;
-         }
+         //  return FALSE;
+         //}
 
         return TRUE;
       }
 
       return FALSE;
-   }
-
-   NewUsed(what = $)
-   "Affect permanent stat changes here."
-   {
-      pbIn_use = TRUE;
-      pbIllusioned = TRUE;
-      plStatmods = [ 0, 0, 0, 0, 0, 0 ];
-
-      if Send(poOwner,@GetKarma) < piKarmaWorthyThreshold
-         AND Send(poOwner,@GetBaseMaxHealth) >= piHpWorthyThreshold
-      {
-         Send(poOwner,@MsgSendUser,#message_rsc=necamulet_used_rsc);
-      }
-      else
-      {
-         Send(poOwner, @MsgSendUser, #message_rsc = necamulet_used_unworthy);
-      }
-
-      Send(self,@AdjustStats);
-      Send(self,@AdjustColor);
-      ptHungerTimer = CreateTimer(self,@HungerTrigger,
-                           Send(Send(SYS,@GetNecromancerBalance),@GetHungerInterval));
-
-      propagate;
    }
 
    AdjustStats()
@@ -956,17 +948,12 @@ messages:
    ReqLeaveOwner()
    "Don't allow new owner while we're in use."
    {
-      // if not IsClass(poOwner,&user) or Send(poOwner,@PlayerIsImmortal) {propagate;}
-      if NOT IsClass(poOwner,&User)
-      {
-         propagate;
-      }
-
-      if pbIn_use
+      if poOwner <> $
+         AND IsClass(poOwner,&User)
       {
          Post(self,@TortureOwner);
 
-         return FALSE;
+         return False;
       }
 
       propagate;
@@ -1001,13 +988,8 @@ messages:
                #damage=Random(viDamage_min,viDamage_max),#report=FALSE) = $
       {
          // We killed someone off... heh heh heh.
-         if pbIn_Use
-            AND Send(self,@DropOnDeath)
+         if Send(self,@DropOnDeath)
          {
-            // Unusing it kills the owner, we don't want to do that yet.
-            //Send(poOwner,@UnuseItem,#what=self);
-            
-            // Amulet goes back into circulation.
             Post(Send(SYS,@GetNecromancerBalance),@PlaceAmulet,#what=self);
          }
 
@@ -1017,38 +999,6 @@ messages:
       }
 
       return;
-   }
-
-   NewUnused(what = $, Recalibrate = FALSE)
-   "When something that can break the curse unuses the item."
-   {
-      local oGuild;
-
-      if ptHungerTimer <> $
-      {
-         DeleteTimer(ptHungerTimer);
-         ptHungerTimer = $;
-      }
-
-      Send(self,@ReplaceIllusions,#notify=FALSE);
-      Send(self,@RestoreStats,#who=what);
-
-      // The player has to die to take this off - the death code handles
-      // sending info to the guild.
-      //if NOT Recalibrate
-      //{
-      //   oGuild = Send(what,@GetGuild);
-      //   if oGuild <> $
-      //      AND IsClass(oGuild,&NecromancerGuild)
-      //   {
-      //      Send(oGuild,@MemberKilled,#victim=what,#killer=what);
-      //   }
-      //}
-
-      pbIn_use = FALSE;
-      pbIllusioned = FALSE;
-
-      propagate;
    }
 
    SendAnimation()

--- a/kod/object/item/passitem/dyebottle.kod
+++ b/kod/object/item/passitem/dyebottle.kod
@@ -306,7 +306,6 @@ messages:
       OR IsClass(apply_on,&Circlet)
       OR IsClass(apply_on,&IvyCirclet)
       OR IsClass(apply_on,&Wizardhat)
-      OR IsClass(apply_on,&HunterSword)
       OR IsClass(apply_on,&GoldShield)
       {
          Send(what,@MsgSendUser,#message_rsc=cant_dye);

--- a/kod/object/item/passitem/weapon/huntsw.kod
+++ b/kod/object/item/passitem/weapon/huntsw.kod
@@ -130,6 +130,7 @@ properties:
    plStatmods = $
 
    pbIn_use = FALSE     // No longer used.
+   pbWarned = FALSE
    piHunger = 0
    piFineHunger = 0
    ptHungerTimer = $
@@ -154,8 +155,6 @@ messages:
    {
       pbCounted = TRUE;
       Send(Send(SYS,@GetNecromancerBalance),@IncrementSwordCount);
-      Send(self,@AdjustColor);
-
       propagate;
    }
 
@@ -184,7 +183,6 @@ messages:
 
          // Post these so that they happen after 'what' actually becomes our owner.
          Post(self,@AdjustStats);
-         Post(self,@AdjustColor);
 
          ptHungerTimer = CreateTimer(self,@HungerTrigger,Send(Send(SYS,@GetNecromancerBalance),
                               @GetHungerInterval));
@@ -443,56 +441,6 @@ messages:
       return;
    }
 
-   AdjustColor()
-   {
-      local Xlat;
-
-      if piHunger > HUNGER_5
-      {
-         Xlat = (XLAT_BASE_VALUE + XLAT_TO_RED);
-      }
-      else
-      {
-         if piHunger > (HUNGER_5*3/5)
-         {
-            Xlat = (XLAT_BASE_VALUE + XLAT_TO_YELLOW);
-         }
-         else
-         {
-            if piHunger > (HUNGER_5*1/5)
-            {
-               Xlat = (XLAT_BASE_VALUE + XLAT_TO_ORANGE);
-            }
-            else
-            {
-               if piHunger > (-HUNGER_5*1/5)
-               {
-                  Xlat = (XLAT_BASE_VALUE + XLAT_TO_SKIN1);
-               }
-               else
-               {
-                  if piHunger > (-HUNGER_5*3/5)
-                  {
-                     Xlat = (XLAT_BASE_VALUE + XLAT_TO_SKIN2);
-                  }
-                  else
-                  {
-                     Xlat = (XLAT_BASE_VALUE + XLAT_TO_SKIN4);
-                  }
-               }
-            }
-         }
-      }
-      Send(self,@SetPaletteTranslation,#translation=Xlat);
-
-      if poOwner <> $
-      {
-         Send(poOwner,@SomethingChanged,#what=self);
-      }
-
-      return;
-   }
-
    HungerTrigger()
    {
       local oSword;
@@ -555,7 +503,6 @@ messages:
       }
 
       Send(self,@AdjustStats);
-      Send(self,@AdjustColor);
 
       if piHunger > HUNGER_5 {
          // Start doing mild damage, losing vigor (4 each time).
@@ -758,14 +705,12 @@ messages:
       // Can 'save up', but only to a point.
       piHunger = Bound(piHunger,-HUNGER_5,$);
       Send(self,@AdjustStats);
-      Send(self,@AdjustColor);
 
       return;
    }
 
    Delete()
    {
-      Send(self,@NewOwner,#what=$);
 
       if pbCounted
       {
@@ -849,23 +794,6 @@ messages:
       }
 
       AddPacket(1,ANIMATE_NONE,2,viGround_group);
-
-      return;
-   }
-
-   SendInventoryAnimation()
-   {
-      local iXLAT;
-      if (piItem_flags & ITEM_PALETTE_MASK) <> 0
-      {
-         // The artists made the gem red in the inv/dropped views
-         // (blue in the look view), so we have to juggle this a little (ugh).
-         iXLAT = Send(SYS,@DecodeSecondaryColor,#xlat=(piItem_flags & ITEM_PALETTE_MASK));
-         iXLAT = Send(SYS,@EncodeTwoColorXLAT,#color1=iXLAT);
-         AddPacket(1,ANIMATE_TRANSLATION,1,iXLAT);
-      }
-
-      AddPacket(1,ANIMATE_NONE,2,viInventory_group);
 
       return;
    }

--- a/kod/object/passive/spell/summrefl.kod
+++ b/kod/object/passive/spell/summrefl.kod
@@ -113,6 +113,17 @@ messages:
          return;
       }
 
+      // Limit reflections.
+      if (Send(self,@CountPlayerReflections,#who=who)
+         >= Send(SETTINGS_OBJECT,@GetPlayerReflectionLimit))
+         AND NOT (IsClass(who,&DM)
+            AND Send(who,@PlayerIsImmortal))
+      {
+         Send(who,@MsgSendUser,#message_rsc=summonreflection_limit_rsc);
+         
+		 return FALSE;
+      }
+
       oReflection = Create(&Reflection,#iSpellpower=iSpellpower,#oMaster=who);
       Send(oReflection,@SetOriginal,#who=who);
 

--- a/kod/util/necbal.kod
+++ b/kod/util/necbal.kod
@@ -312,49 +312,54 @@ messages:
    GenerateAmulet()
    "Actually does the artifact generation."
    {
-      local oAmulet;
+      // Amulets can be purchased now. No need to put back into population.
+      //local oAmulet;
 
-      ptGenerateAmulet = $;
-      oAmulet = Create(&NecromancerAmulet);
-      Send(self,@PlaceAmulet,#what=oAmulet);
+      //ptGenerateAmulet = $;
+      //oAmulet = Create(&NecromancerAmulet);
+      //Send(self,@PlaceAmulet,#what=oAmulet);
 
       return;
    }
 
    PlaceAmulet(what=$)
    {
-      local iLocation;
+      // Amulets can be purchased now. No need to put back into population, just delete on player drop.
+      //local iLocation;
 
-      if what = $
-      {
-         return;
-      }
+      //if what = $
+      //{
+      //   return;
+      //}
 
-      if plAmuletLocations = $
-      {
-         Debug("Nowhere to place the amulet!");
-         Send(what,@Delete);
+      //if plAmuletLocations = $
+      //{
+      //   Debug("Nowhere to place the amulet!");
+      //   Send(what,@Delete);
 
-         return;
-      }
+      //   return;
+      //}
 
-      iLocation = Random(1,Length(plAmuletLocations));
+      //iLocation = Random(1,Length(plAmuletLocations));
 
-      Send(Send(SYS,@FindRoomByNum,#num=Nth(Nth(plAmuletLocations,iLocation),1)),
-            @NewHold,#what=what,#new_row=Nth(Nth(plAmuletLocations,iLocation),2),
-                                 #new_col=Nth(Nth(plAmuletLocations,iLocation),3),
-                                 #fine_row=Nth(Nth(plAmuletLocations,iLocation),4),
-                                 #fine_col=Nth(Nth(plAmuletLocations,iLocation),5));
+      //Send(Send(SYS,@FindRoomByNum,#num=Nth(Nth(plAmuletLocations,iLocation),1)),
+      //      @NewHold,#what=what,#new_row=Nth(Nth(plAmuletLocations,iLocation),2),
+      //                           #new_col=Nth(Nth(plAmuletLocations,iLocation),3),
+      //                           #fine_row=Nth(Nth(plAmuletLocations,iLocation),4),
+      //                           #fine_col=Nth(Nth(plAmuletLocations,iLocation),5));
 
-      if Send(what,@GetOwner) = $
-      {
-         Debug("Tried to place an amulet, but owner is still $.");
-         Send(what,@Delete);
-      }
-      else
-      {
-         Debug("Placed an amulet in ",Send(Send(what,@GetOwner),@GetName));
-      }
+      //if Send(what,@GetOwner) = $
+      //{
+      //   Debug("Tried to place an amulet, but owner is still $.");
+      //   Send(what,@Delete);
+      //}
+      //else
+      //{
+      //   Debug("Placed an amulet in ",Send(Send(what,@GetOwner),@GetName));
+      //}
+
+        Send(what,@Delete);
+        Debug("Amulet of Three dropped by player, deleting.");
 
       return;
    }
@@ -405,49 +410,54 @@ messages:
    GenerateSword()
    "Actually does the artifact generation."
    {
-      local oSword;
+      // HunterSwords can be purchased now. No need to put back into population.
+      //local oSword;
 
-      ptGenerateSword = $;
-      oSword = Create(&HunterSword);
-      Send(self,@PlaceSword,#what=oSword);
+      //ptGenerateSword = $;
+      //oSword = Create(&HunterSword);
+      //Send(self,@PlaceSword,#what=oSword);
 
       return;
    }
 
    PlaceSword(what=$)
    {
-      local iLocation;
+      // HunterSwords can be purchased now. No need to put back into population. Delete on player death.
+      //local iLocation;
 
-      if what = $
-      {
-         return;
-      }
+      //if what = $
+      //{
+      //   return;
+      //}
 
-      if plSwordLocations = $
-      {
-         Debug("Nowhere to place the sword!");
-         Send(what,@Delete);
+      //if plSwordLocations = $
+      //{
+      //   Debug("Nowhere to place the sword!");
+      //   Send(what,@Delete);
 
-         return;
-      }
+      //   return;
+      //}
 
-      iLocation = Random(1,Length(plSwordLocations));
+      //iLocation = Random(1,Length(plSwordLocations));
 
-      Send(Send(SYS,@FindRoomByNum,#num=Nth(Nth(plSwordLocations,iLocation),1)),
-            @NewHold,#what=what,#new_row=Nth(Nth(plSwordLocations,iLocation),2),
-                                 #new_col=Nth(Nth(plSwordLocations,iLocation),3),
-                                 #fine_row=Nth(Nth(plSwordLocations,iLocation),4),
-                                 #fine_col=Nth(Nth(plSwordLocations,iLocation),5));
+      //Send(Send(SYS,@FindRoomByNum,#num=Nth(Nth(plSwordLocations,iLocation),1)),
+      //      @NewHold,#what=what,#new_row=Nth(Nth(plSwordLocations,iLocation),2),
+      //                           #new_col=Nth(Nth(plSwordLocations,iLocation),3),
+      //                           #fine_row=Nth(Nth(plSwordLocations,iLocation),4),
+      //                           #fine_col=Nth(Nth(plSwordLocations,iLocation),5));
 
-      if Send(what,@GetOwner) = $
-      {
-         Debug("Tried to place a sword, but owner is still $.");
-         Send(what,@Delete);
-      }
-      else
-      {
-         Debug("Placed a sword in ",Send(Send(what,@GetOwner),@GetName));
-      }
+      //if Send(what,@GetOwner) = $
+      //{
+      //   Debug("Tried to place a sword, but owner is still $.");
+      //   Send(what,@Delete);
+      //}
+      //else
+      //{
+      //   Debug("Placed a sword in ",Send(Send(what,@GetOwner),@GetName));
+      //}
+
+        Send(what,@Delete);
+        Debug("Hunter Sword dropped by player, deleting.");
 
       return;
    }


### PR DESCRIPTION
1. Fixed the SoTh losing its color when used. So sword can now be colored as normal.

2. When a sword or amulet is dropped or lost by a player it will be deleted rather than placed into brax. They can be purchased, no need for them to cycle.

3. Necrobalance will no longer generate/place hunter swords or amulets since they are able to be purchased.

4. Fixed amulet will get stat benefit immediately on pickup and continue whether used or not used. Same benefit as the SOTH (do not have to be using the SoTH for the stat benefit).

5. Previous old versions of game the Ao3 could not be 'un used' once used the first time. Trying to unuse it would cause damage similar to the damage caused trying to drop the SOTH. Someone commented out the code that stopped it from being unused, meaning an Ao3 holder could unuse and drop the Ao3 at will. With no downside unlike the SOTH.

New code implemented to still allow an Ao3 user to use and unuse the amulet, but they are not allowed to drop it without damage - this makes it the same as the SoTH.

Similar benefits and similar risks/trade offs between SOTH and Ao3.